### PR TITLE
feat: implement /api/upload route with dummy image upload and prediction

### DIFF
--- a/pages/api/upload.ts
+++ b/pages/api/upload.ts
@@ -1,0 +1,51 @@
+import nextConnect from 'next-connect';
+import multer from 'multer';
+import { NextApiRequest, NextApiResponse } from 'next';
+import fs from 'fs';
+import path from 'path';
+
+const uploadDir = path.join(process.cwd(), 'uploads');
+if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir);
+
+const upload = multer({
+  storage: multer.diskStorage({
+    destination: uploadDir,
+    filename: (req, file, cb) => {
+      cb(null, Date.now() + '-' + file.originalname);
+    },
+  }),
+  fileFilter: (req, file, cb) => {
+    if (!file.mimetype.startsWith('image/')) {
+      return cb(new Error('Only image files are allowed!'));
+    }
+    cb(null, true);
+  },
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5MB
+});
+
+const apiRoute = nextConnect<NextApiRequest, NextApiResponse>({
+  onError(error, req, res) {
+    res.status(500).json({ error: error.message });
+  },
+  onNoMatch(req, res) {
+    res.status(405).json({ error: `Method ${req.method} not allowed` });
+  },
+});
+
+apiRoute.use(upload.single('image'));
+
+apiRoute.post((req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No image uploaded' });
+  }
+
+  res.status(200).json({ label: 'Moi Moi' });
+});
+
+export default apiRoute;
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};

--- a/uploads/.gitkeep
+++ b/uploads/.gitkeep
@@ -1,0 +1,1 @@
+# This file allows Git to track the uploads folder


### PR DESCRIPTION
- Created a Next.js API route at /api/upload using next-connect and multer
- Accepts POST requests with an image file, validates image type, and stores it in /uploads
- Returns a dummy classification result { label: "Moi Moi" }
- Sets the foundation for integrating the ResNet18 model later
